### PR TITLE
🔀 :: (#152) 전체 레시피 조회시 api가 계속 호출됨 

### DIFF
--- a/data/src/main/java/com/project/data/remote/datasource/recipe/AllRecipePagingSource.kt
+++ b/data/src/main/java/com/project/data/remote/datasource/recipe/AllRecipePagingSource.kt
@@ -6,9 +6,8 @@ import com.project.data.remote.model.response.RecipeResponse
 import com.project.data.remote.network.api.RecipeApi
 import com.project.data.remote.util.safeApiCall
 
-class RecipePagingSource(
+class AllRecipePagingSource(
     private val recipeApi: RecipeApi,
-    private val filter: String? = null
 ) : PagingSource<Int, RecipeResponse>() {
     override fun getRefreshKey(state: PagingState<Int, RecipeResponse>): Int? {
         return state.anchorPosition?.let { anchorPosition ->
@@ -20,22 +19,15 @@ class RecipePagingSource(
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, RecipeResponse> {
         val page = params.key ?: 0
         val response = safeApiCall {
-            if (filter == "recommend") {
-                recipeApi.getRecommendRecipes(
-                    page = page,
-                    size = params.loadSize
-                )
-            } else {
-                recipeApi.getAllRecipes(
-                    page = page,
-                    size = params.loadSize
-                )
-            }
+            recipeApi.getAllRecipes(
+                page = page,
+                size = params.loadSize
+            )
         }
 
         return LoadResult.Page(
             data = response.recipeList,
-            prevKey = if (page == 1) null else page - 1,
+            prevKey = if (page == 0) null else page - 1,
             nextKey = if (response.recipeList.isEmpty()) null else page + 1
         )
     }

--- a/data/src/main/java/com/project/data/remote/datasource/recipe/RecommendRecipePagingSource.kt
+++ b/data/src/main/java/com/project/data/remote/datasource/recipe/RecommendRecipePagingSource.kt
@@ -1,0 +1,34 @@
+package com.project.data.remote.datasource.recipe
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.project.data.remote.model.response.RecipeResponse
+import com.project.data.remote.network.api.RecipeApi
+import com.project.data.remote.util.safeApiCall
+
+class RecommendRecipePagingSource(
+    private val recipeApi: RecipeApi,
+) : PagingSource<Int, RecipeResponse>() {
+    override fun getRefreshKey(state: PagingState<Int, RecipeResponse>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            val anchorPage = state.closestPageToPosition(anchorPosition)
+            anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
+        }
+    }
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, RecipeResponse> {
+        val page = params.key ?: 0
+        val response = safeApiCall {
+            recipeApi.getRecommendRecipes(
+                page = page,
+                size = params.loadSize
+            )
+        }
+
+        return LoadResult.Page(
+            data = response.recipeList,
+            prevKey = if (page == 0) null else page - 1,
+            nextKey = if (response.recipeList.isEmpty()) null else page + 1
+        )
+    }
+}

--- a/data/src/main/java/com/project/data/repository/RecipeRepositoryImpl.kt
+++ b/data/src/main/java/com/project/data/repository/RecipeRepositoryImpl.kt
@@ -4,8 +4,9 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
+import com.project.data.remote.datasource.recipe.AllRecipePagingSource
 import com.project.data.remote.datasource.recipe.RecipeDataSource
-import com.project.data.remote.datasource.recipe.RecipePagingSource
+import com.project.data.remote.datasource.recipe.RecommendRecipePagingSource
 import com.project.data.remote.model.request.asRecipesRequest
 import com.project.data.remote.model.response.asRecipeDetailResponseModel
 import com.project.data.remote.model.response.asRecipeResponseModel
@@ -23,11 +24,10 @@ class RecipeRepositoryImpl @Inject constructor(
 ) : RecipeRepository {
     override fun getRecommendRecipes(): Flow<PagingData<RecipeResponseModel>> {
         return Pager(
-            config = PagingConfig(pageSize = 5),
+            config = PagingConfig(pageSize = 2),
             pagingSourceFactory = {
-                RecipePagingSource(
-                    recipeApi = recipeApi,
-                    filter = "recommend"
+                RecommendRecipePagingSource(
+                    recipeApi = recipeApi
                 )
             }
         ).flow.map { pagingData ->
@@ -37,9 +37,9 @@ class RecipeRepositoryImpl @Inject constructor(
 
     override fun getAllRecipes(): Flow<PagingData<RecipeResponseModel>> {
         return Pager(
-            config = PagingConfig(pageSize = 5),
+            config = PagingConfig(pageSize = 2),
             pagingSourceFactory = {
-                RecipePagingSource(recipeApi = recipeApi)
+                AllRecipePagingSource(recipeApi = recipeApi)
             }
         ).flow.map { pagingData ->
             pagingData.map { it.asRecipeResponseModel() }

--- a/presentation/src/main/java/com/project/presentation/view/main/MainScreen.kt
+++ b/presentation/src/main/java/com/project/presentation/view/main/MainScreen.kt
@@ -70,11 +70,8 @@ fun MainScreen(
 
     var currentPage by remember { mutableStateOf(RECOMMEND) }
 
-    val recipes = if (currentPage == RECOMMEND) {
-        mainViewModel.getRecipes(RECOMMEND).collectAsLazyPagingItems()
-    } else {
-        mainViewModel.getRecipes(ALL).collectAsLazyPagingItems()
-    }
+    val recommendRecipes = mainViewModel.getRecommendRecipes().collectAsLazyPagingItems()
+    val allRecipes = mainViewModel.getAllRecipes().collectAsLazyPagingItems()
 
     Scaffold(
         floatingActionButton = {
@@ -142,12 +139,12 @@ fun MainScreen(
                 if (page == RECOMMEND) {
                     RecipeList(
                         spanItem = { TopItem(recipe = it) { navigateToDetail(1) } },
-                        recipes = recipes
+                        recipes = recommendRecipes
                     ) {
                         navigateToDetail(1)
                     }
                 } else {
-                    RecipeList(recipes = recipes) {
+                    RecipeList(recipes = allRecipes) {
                         navigateToDetail(1)
                     }
                 }

--- a/presentation/src/main/java/com/project/presentation/viewmodel/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/project/presentation/viewmodel/main/MainViewModel.kt
@@ -1,6 +1,5 @@
 package com.project.presentation.viewmodel.main
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
@@ -9,8 +8,6 @@ import com.project.domain.model.auth.response.RecipeResponseModel
 import com.project.domain.usecase.recipe.GetAllRecipesUseCase
 import com.project.domain.usecase.recipe.GetRecommendRecipesUseCase
 import com.project.domain.usecase.recipe.SearchRecipeUseCase
-import com.project.presentation.view.main.ALL
-import com.project.presentation.view.main.RECOMMEND
 import com.project.presentation.viewmodel.util.UiState
 import com.project.presentation.viewmodel.util.exceptionHandling
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -28,15 +25,10 @@ class MainViewModel @Inject constructor(
 ) : ViewModel() {
     private val _uiState: MutableStateFlow<UiState<RecipeResponseModel>> = MutableStateFlow(UiState.Loading)
     val uiState = _uiState.asStateFlow()
-    fun getRecipes(type: Int = ALL): Flow<PagingData<RecipeResponseModel>> {
-        val recipes = if (type == RECOMMEND) {
-            getRecommendRecipesUseCase().cachedIn(viewModelScope)
-        } else {
-            getAllRecipesUseCase().cachedIn(viewModelScope)
-        }
-        Log.d("recipes", recipes.toString())
-        return recipes
-    }
+
+    fun getRecommendRecipes(): Flow<PagingData<RecipeResponseModel>> = getRecommendRecipesUseCase().cachedIn(viewModelScope)
+
+    fun getAllRecipes(): Flow<PagingData<RecipeResponseModel>> = getAllRecipesUseCase().cachedIn(viewModelScope)
 
     fun searchRecipe(name: String) {
         viewModelScope.launch {


### PR DESCRIPTION
- 하나의 PagingSource로 관리되던 api를 개별적으로 분리
- MainScreen에서 리스트를 별도의 변수로 관리