### PR TITLE
🔀 :: (#165) 프로필 페이지에서 디테일 페이지로 이동 구현

### DIFF
--- a/design_system/src/main/java/com/project/design_system/component/SoloRecipeButton.kt
+++ b/design_system/src/main/java/com/project/design_system/component/SoloRecipeButton.kt
@@ -16,6 +16,7 @@ import com.project.design_system.theme.SoloRecipeColor
 fun SoloRecipeButton(
     modifier: Modifier = Modifier,
     text: String,
+    textColor: Color = SoloRecipeColor.White,
     enabled: Boolean = true,
     containerColor: Color,
     contentPadding: PaddingValues = PaddingValues(vertical = 16.dp),
@@ -31,7 +32,7 @@ fun SoloRecipeButton(
     ) {
         Body3(
             text = text,
-            textColor = SoloRecipeColor.White,
+            textColor = textColor,
             textAlign = TextAlign.Center
         )
     }

--- a/presentation/src/main/java/com/project/presentation/view/detail/DetailScreen.kt
+++ b/presentation/src/main/java/com/project/presentation/view/detail/DetailScreen.kt
@@ -55,6 +55,7 @@ import com.skydoves.landscapist.glide.GlideImage
 fun DetailScreen(
     modifier: Modifier = Modifier,
     index: String?,
+    isLikedRecipe: Boolean?,
     detailViewModel: DetailViewModel = hiltViewModel(),
 ) {
     val recipeIndex = checkNotNull(index)
@@ -78,7 +79,12 @@ fun DetailScreen(
                         .verticalScroll(rememberScrollState()),
                 ) {
                     Spacer(modifier = modifier.height(16.dp))
-                    DetailTitle(recipeDetail = state.data) { detailViewModel.likeRecipe(index.toLong()) }
+                    DetailTitle(
+                        recipeDetail = state.data,
+                        isLikedRecipe = checkNotNull(isLikedRecipe)
+                    ) {
+                        detailViewModel.likeRecipe(index.toLong())
+                    }
                     Spacer(modifier = modifier.height(26.dp))
                     Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
                         val recipeProcess = state.data?.recipeProcess
@@ -114,6 +120,7 @@ fun DetailScreen(
                 }
             }
         }
+
         UiState.Unauthorized -> {}
         UiState.NotFound -> {}
         else -> {}
@@ -123,10 +130,11 @@ fun DetailScreen(
 @Composable
 fun DetailTitle(
     modifier: Modifier = Modifier,
+    isLikedRecipe: Boolean,
     recipeDetail: RecipeDetailResponseModel?,
     onLike: (Boolean) -> Unit
 ) {
-    var liked by remember { mutableStateOf(false) }
+    var liked by remember { mutableStateOf(isLikedRecipe) }
 
     GlideImage(
         modifier = modifier

--- a/presentation/src/main/java/com/project/presentation/view/detail/navigation/DetailNavigation.kt
+++ b/presentation/src/main/java/com/project/presentation/view/detail/navigation/DetailNavigation.kt
@@ -10,15 +10,21 @@ import com.project.presentation.view.detail.DetailScreen
 
 const val detailRoute = "detail_route"
 
-fun NavController.navigateToDetail(index: Long) {
-    this.navigate("$detailRoute/$index")
+fun NavController.navigateToDetail(index: Long, isLikedRecipe: Boolean = false) {
+    this.navigate("$detailRoute/$index/$isLikedRecipe")
 }
 
 fun NavGraphBuilder.detailScreen() {
     composable(
-        route = "$detailRoute/{index}",
-        arguments = listOf(navArgument("index") { type = NavType.StringType })
+        route = "$detailRoute/{index}/{isLikedRecipe}",
+        arguments = listOf(
+            navArgument("index") { type = NavType.StringType },
+            navArgument("isLikedRecipe") { type = NavType.BoolType }
+        )
     ) { backStackEntry ->
-        DetailScreen(index = backStackEntry.arguments?.getString("index"))
+        DetailScreen(
+            index = backStackEntry.arguments?.getString("index"),
+            isLikedRecipe = backStackEntry.arguments?.getBoolean("isLikedRecipe")
+        )
     }
 }

--- a/presentation/src/main/java/com/project/presentation/view/registration/RegistrationScreen.kt
+++ b/presentation/src/main/java/com/project/presentation/view/registration/RegistrationScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -73,16 +74,29 @@ fun RegistrationScreen(
     type: String?,
     navigateToMain: () -> Unit,
 ) {
-    var step by remember { mutableStateOf(5) }
-    var title by remember { mutableStateOf("") }
-
     val recipeProcess: List<RecipeRequestModel> = listOf()
 
+    val recipeUiState by registrationViewModel.recipeUiState.collectAsStateWithLifecycle()
     val createUiState by registrationViewModel.createUiState.collectAsStateWithLifecycle()
     val modifyUiState by registrationViewModel.modifyUiState.collectAsStateWithLifecycle()
 
     var removeClicked by remember { mutableStateOf(false) }
     var modifyClicked by remember { mutableStateOf(false) }
+
+    var step by remember { mutableStateOf(5) }
+    var title by remember {
+        mutableStateOf(
+            if (type == "modify") {
+                when (val state = recipeUiState) {
+                    is UiState.Success -> { state.data!!.name }
+                    else -> ""
+                }
+            } else ""
+        )
+    }
+    LaunchedEffect(Unit) {
+        if (type == "modify") registrationViewModel.getRecipeDetail(checkNotNull(index!!.toLong()))
+    }
 
     if (removeClicked) {
         SoloRecipeDialog(
@@ -151,6 +165,20 @@ fun RegistrationScreen(
         UiState.Unauthorized -> {}
         else -> {}
     }
+
+    when (modifyUiState) {
+        UiState.Loading -> {}
+        is UiState.Success -> {
+            navigateToMain()
+        }
+
+        UiState.BadRequest -> {}
+        UiState.Unauthorized -> {}
+        UiState.Forbidden -> {}
+        UiState.NotFound -> {}
+        else -> {}
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -170,7 +198,18 @@ fun RegistrationScreen(
         }
         Column(modifier = modifier.verticalScroll(rememberScrollState())) {
             Spacer(modifier = modifier.height(16.dp))
-            Thumbnail(imageUpload = registrationViewModel::imageUpload)
+            Thumbnail(
+                imageUpload = registrationViewModel::imageUpload,
+                image = if (type == "modify") {
+                    when (val state = recipeUiState) {
+                        is UiState.Success -> {
+                            state.data!!.thumbnail
+                        }
+
+                        else -> ""
+                    }
+                } else null
+            )
             Spacer(modifier = modifier.height(9.dp))
             ThumbnailTitle(title = title) { title = it }
             Spacer(modifier = modifier.height(30.dp))
@@ -181,7 +220,18 @@ fun RegistrationScreen(
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
                 repeat(step) {
-                    StepItem(imageUpload = registrationViewModel::imageUpload)
+                    StepItem(
+                        imageUpload = registrationViewModel::imageUpload,
+                        step = if (type == "modify") {
+                            when (val state = recipeUiState) {
+                                is UiState.Success -> {
+                                    Pair(state.data!!.recipeProcess[it].image, state.data.recipeProcess[it].description)
+                                }
+
+                                else -> Pair("", "")
+                            }
+                        } else null
+                    )
                 }
             }
             Spacer(modifier = modifier.height(25.dp))
@@ -216,7 +266,8 @@ fun RegistrationScreen(
 @Composable
 fun Thumbnail(
     modifier: Modifier = Modifier,
-    imageUpload: (List<MultipartBody.Part>) -> Unit
+    imageUpload: (List<MultipartBody.Part>) -> Unit,
+    image: String? = null
 ) {
     val context = LocalContext.current
     val registrationImageUri = remember { mutableStateOf(Uri.EMPTY) }
@@ -228,98 +279,59 @@ fun Thumbnail(
     }
     var clicked by remember { mutableStateOf(false) }
 
-    if (!clicked) {
-        Box(
-            modifier = modifier
-                .fillMaxWidth()
-                .height(250.dp)
-                .padding(horizontal = 26.dp)
-                .background(
-                    color = SoloRecipeColor.Secondary10,
-                    shape = RoundedCornerShape(8.dp)
-                )
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                    onClick = {
-                        galleryLauncher.launch("image/*")
-                        clicked = !clicked
-                    }
-                )
-        ) {
-            IcCamera(
-                modifier = modifier
-                    .size(40.dp, 32.dp)
-                    .align(Center),
-                contentDescription = "camera"
-            )
-        }
-    } else {
-        GlideImage(
-            imageModel = { registrationImageUri.value },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(250.dp)
-                .padding(horizontal = 26.dp)
-                .clip(shape = RoundedCornerShape(8.dp))
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                    onClick = { galleryLauncher.launch("image/*") }
-                ),
-            imageOptions = ImageOptions(contentScale = ContentScale.Crop)
-        )
-    }
-}
-
-@Composable
-fun StepItem(
-    modifier: Modifier = Modifier,
-    imageUpload: (List<MultipartBody.Part>) -> Unit
-) {
-    var content by remember { mutableStateOf("") }
-    val context = LocalContext.current
-    val registrationImageUri = remember { mutableStateOf(Uri.EMPTY) }
-    val galleryLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) {
-        registrationImageUri.value = it
-        val file = File(getPathFromUri(context, registrationImageUri.value))
-        val partList = changeToPartList(file)
-        imageUpload(partList)
-    }
-    var clicked by remember { mutableStateOf(false) }
-
-    Row(modifier = modifier.height(70.dp)) {
-        if (!clicked) {
-            Box(
-                modifier = modifier
-                    .width(80.dp)
-                    .fillMaxHeight()
-                    .background(
-                        color = SoloRecipeColor.Secondary10,
-                        shape = RoundedCornerShape(8.dp)
-                    )
-                    .clickable(
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = null,
-                        onClick = {
-                            galleryLauncher.launch("image/*")
-                            clicked = !clicked
-                        }
-                    )
-            ) {
-                IcCamera(
+    when (image) {
+        null -> {
+            if (!clicked) {
+                Box(
                     modifier = modifier
-                        .size(20.dp, 16.dp)
-                        .align(Center),
-                    contentDescription = "camera"
+                        .fillMaxWidth()
+                        .height(250.dp)
+                        .padding(horizontal = 26.dp)
+                        .background(
+                            color = SoloRecipeColor.Secondary10,
+                            shape = RoundedCornerShape(8.dp)
+                        )
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = {
+                                galleryLauncher.launch("image/*")
+                                clicked = !clicked
+                            }
+                        )
+                ) {
+                    IcCamera(
+                        modifier = modifier
+                            .size(40.dp, 32.dp)
+                            .align(Center),
+                        contentDescription = "camera"
+                    )
+                }
+            } else {
+                GlideImage(
+                    imageModel = { registrationImageUri.value },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(250.dp)
+                        .padding(horizontal = 26.dp)
+                        .clip(shape = RoundedCornerShape(8.dp))
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = { galleryLauncher.launch("image/*") }
+                        ),
+                    imageOptions = ImageOptions(contentScale = ContentScale.Crop)
                 )
             }
-        } else {
+        }
+
+        else -> {
             GlideImage(
-                imageModel = { registrationImageUri.value },
+                imageModel = { image },
                 modifier = Modifier
-                    .width(80.dp)
-                    .fillMaxHeight()
+                    .fillMaxWidth()
+                    .height(250.dp)
+                    .padding(horizontal = 26.dp)
                     .clip(shape = RoundedCornerShape(8.dp))
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
@@ -328,6 +340,88 @@ fun StepItem(
                     ),
                 imageOptions = ImageOptions(contentScale = ContentScale.Crop)
             )
+        }
+    }
+}
+
+@Composable
+fun StepItem(
+    modifier: Modifier = Modifier,
+    imageUpload: (List<MultipartBody.Part>) -> Unit,
+    step: Pair<String, String>? = null
+) {
+    var content by remember { mutableStateOf(step?.second ?: "") }
+    var clicked by remember { mutableStateOf(false) }
+
+    val context = LocalContext.current
+    val registrationImageUri = remember { mutableStateOf(Uri.EMPTY) }
+    val galleryLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) {
+        registrationImageUri.value = it
+        val file = File(getPathFromUri(context, registrationImageUri.value))
+        val partList = changeToPartList(file)
+        imageUpload(partList)
+    }
+
+    Row(modifier = modifier.height(70.dp)) {
+        when (step?.first) {
+            null -> {
+                if (!clicked) {
+                    Box(
+                        modifier = modifier
+                            .width(80.dp)
+                            .fillMaxHeight()
+                            .background(
+                                color = SoloRecipeColor.Secondary10,
+                                shape = RoundedCornerShape(8.dp)
+                            )
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null,
+                                onClick = {
+                                    galleryLauncher.launch("image/*")
+                                    clicked = !clicked
+                                }
+                            )
+                    ) {
+                        IcCamera(
+                            modifier = modifier
+                                .size(20.dp, 16.dp)
+                                .align(Center),
+                            contentDescription = "camera"
+                        )
+                    }
+                } else {
+                    GlideImage(
+                        imageModel = { registrationImageUri.value },
+                        modifier = Modifier
+                            .width(80.dp)
+                            .fillMaxHeight()
+                            .clip(shape = RoundedCornerShape(8.dp))
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null,
+                                onClick = { galleryLauncher.launch("image/*") }
+                            ),
+                        imageOptions = ImageOptions(contentScale = ContentScale.Crop)
+                    )
+                }
+            }
+
+            else -> {
+                GlideImage(
+                    imageModel = { step.second },
+                    modifier = Modifier
+                        .width(80.dp)
+                        .fillMaxHeight()
+                        .clip(shape = RoundedCornerShape(8.dp))
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = { galleryLauncher.launch("image/*") }
+                        ),
+                    imageOptions = ImageOptions(contentScale = ContentScale.Crop)
+                )
+            }
         }
         Spacer(modifier = Modifier.width(10.dp))
         Column(

--- a/presentation/src/main/java/com/project/presentation/view/registration/RegistrationScreen.kt
+++ b/presentation/src/main/java/com/project/presentation/view/registration/RegistrationScreen.kt
@@ -46,10 +46,13 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.project.design_system.component.SoloRecipeAppBar
 import com.project.design_system.component.SoloRecipeButton
+import com.project.design_system.component.SoloRecipeDialog
 import com.project.design_system.theme.Body2
 import com.project.design_system.theme.Body3
 import com.project.design_system.theme.IcCamera
+import com.project.design_system.theme.IcTrashcan
 import com.project.design_system.theme.SoloRecipeColor
+import com.project.design_system.theme.SoloRecipeTheme
 import com.project.design_system.theme.SoloRecipeTypography
 import com.project.domain.model.recipe.request.RecipeRequestModel
 import com.project.domain.model.recipe.request.RecipesRequestModel
@@ -78,9 +81,72 @@ fun RegistrationScreen(
     val createUiState by registrationViewModel.createUiState.collectAsStateWithLifecycle()
     val modifyUiState by registrationViewModel.modifyUiState.collectAsStateWithLifecycle()
 
+    var removeClicked by remember { mutableStateOf(false) }
+    var modifyClicked by remember { mutableStateOf(false) }
+
+    if (removeClicked) {
+        SoloRecipeDialog(
+            title = "레시피 삭제",
+            description = "글을 삭제하시면 복구가 불가능합니다.",
+            onDismiss = { removeClicked = false }
+        ) {
+            SoloRecipeButton(
+                modifier = modifier.weight(1f),
+                text = "취소",
+                containerColor = SoloRecipeTheme.color.Primary10
+            ) {
+                removeClicked = false
+            }
+            Spacer(modifier = modifier.width(10.dp))
+            SoloRecipeButton(
+                modifier = modifier
+                    .border(width = 1.dp, color = SoloRecipeTheme.color.Primary10, shape = RoundedCornerShape(8.dp))
+                    .weight(1f),
+                text = "삭제",
+                textColor = SoloRecipeTheme.color.Black,
+                containerColor = SoloRecipeTheme.color.White,
+            ) {
+
+            }
+        }
+    }
+
+    if (modifyClicked) {
+        SoloRecipeDialog(title = "레시피 수정", description = "레시피를 수정하시겠습니까?", onDismiss = { modifyClicked = false }) {
+            SoloRecipeButton(
+                modifier = modifier.weight(1f),
+                text = "취소",
+                containerColor = SoloRecipeTheme.color.Primary10
+            ) {
+                modifyClicked = false
+            }
+            Spacer(modifier = modifier.width(10.dp))
+            SoloRecipeButton(
+                modifier = modifier
+                    .border(width = 1.dp, color = SoloRecipeTheme.color.Primary10, shape = RoundedCornerShape(8.dp))
+                    .weight(1f),
+                text = "수정",
+                textColor = SoloRecipeTheme.color.Black,
+                containerColor = SoloRecipeTheme.color.White
+            ) {
+                registrationViewModel.modifyRecipe(
+                    index = checkNotNull(index?.toLong()),
+                    body = RecipesRequestModel(
+                        name = title,
+                        thumbnail = "",
+                        recipeProcess = recipeProcess
+                    )
+                )
+            }
+        }
+    }
+
     when (createUiState) {
         UiState.Loading -> {}
-        is UiState.Success -> { navigateToMain() }
+        is UiState.Success -> {
+            navigateToMain()
+        }
+
         UiState.BadRequest -> {}
         UiState.Unauthorized -> {}
         else -> {}
@@ -90,7 +156,18 @@ fun RegistrationScreen(
             .fillMaxSize()
             .background(SoloRecipeColor.White)
     ) {
-        SoloRecipeAppBar { }
+        SoloRecipeAppBar(
+            endIcons = {
+                if (type == "modify") {
+                    IcTrashcan(
+                        modifier = modifier.clickable { removeClicked = true },
+                        contentDescription = "remove"
+                    )
+                }
+            }
+        ) {
+
+        }
         Column(modifier = modifier.verticalScroll(rememberScrollState())) {
             Spacer(modifier = modifier.height(16.dp))
             Thumbnail(imageUpload = registrationViewModel::imageUpload)
@@ -127,14 +204,7 @@ fun RegistrationScreen(
                             )
                         )
                     } else {
-                        registrationViewModel.modifyRecipe(
-                            index = checkNotNull(index?.toLong()),
-                            body = RecipesRequestModel(
-                                name = title,
-                                thumbnail = "",
-                                recipeProcess = recipeProcess
-                            )
-                        )
+                        modifyClicked = true
                     }
                 }
             )
@@ -168,7 +238,7 @@ fun Thumbnail(
                     color = SoloRecipeColor.Secondary10,
                     shape = RoundedCornerShape(8.dp)
                 )
-                .clickable (
+                .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
                     onClick = {
@@ -228,7 +298,7 @@ fun StepItem(
                         color = SoloRecipeColor.Secondary10,
                         shape = RoundedCornerShape(8.dp)
                     )
-                    .clickable (
+                    .clickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null,
                         onClick = {

--- a/presentation/src/main/java/com/project/presentation/view/registration/navigation/RegistrationNavigation.kt
+++ b/presentation/src/main/java/com/project/presentation/view/registration/navigation/RegistrationNavigation.kt
@@ -10,7 +10,7 @@ import com.project.presentation.view.registration.RegistrationScreen
 const val registrationRoute = "registration_route"
 
 fun NavController.navigateToRegistration(type: String = "registration", index: Long? = null) {
-    val route = if (index != null) "$registrationRoute/$type/$index" else "$registrationRoute/$type"
+    val route = if (index != null) "$registrationRoute/$type?index=$index" else "$registrationRoute/$type"
     this.navigate(route)
 }
 

--- a/presentation/src/main/java/com/project/presentation/viewmodel/registration/RegistrationViewModel.kt
+++ b/presentation/src/main/java/com/project/presentation/viewmodel/registration/RegistrationViewModel.kt
@@ -3,8 +3,10 @@ package com.project.presentation.viewmodel.registration
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.project.domain.model.recipe.request.RecipesRequestModel
+import com.project.domain.model.recipe.response.RecipeDetailResponseModel
 import com.project.domain.usecase.image.ImageUploadUseCase
 import com.project.domain.usecase.recipe.CreateRecipeUseCase
+import com.project.domain.usecase.recipe.GetRecipeDetailUseCase
 import com.project.domain.usecase.recipe.ModifyRecipeUseCase
 import com.project.presentation.viewmodel.util.UiState
 import com.project.presentation.viewmodel.util.exceptionHandling
@@ -19,13 +21,17 @@ import javax.inject.Inject
 class RegistrationViewModel @Inject constructor(
     private val createRecipeUseCase: CreateRecipeUseCase,
     private val imageUploadUseCase: ImageUploadUseCase,
-    private val modifyRecipeUseCase: ModifyRecipeUseCase
+    private val modifyRecipeUseCase: ModifyRecipeUseCase,
+    private val getRecipeDetailUseCase: GetRecipeDetailUseCase
 ) : ViewModel() {
     private val _createUiState: MutableStateFlow<UiState<Nothing>> = MutableStateFlow(UiState.Loading)
     val createUiState = _createUiState.asStateFlow()
 
     private val _modifyUiState: MutableStateFlow<UiState<Nothing>> = MutableStateFlow(UiState.Loading)
     val modifyUiState = _modifyUiState.asStateFlow()
+
+    private val _recipeUiState: MutableStateFlow<UiState<RecipeDetailResponseModel>> = MutableStateFlow(UiState.Loading)
+    val recipeUiState = _recipeUiState
     fun createRecipe(body: RecipesRequestModel) {
         viewModelScope.launch {
             createRecipeUseCase(body)
@@ -64,6 +70,20 @@ class RegistrationViewModel @Inject constructor(
                         unauthorizedAction = { _modifyUiState.value = UiState.Unauthorized },
                         forbiddenAction = { _modifyUiState.value = UiState.Forbidden },
                         notFoundAction = { _modifyUiState.value = UiState.NotFound }
+                    )
+                }
+        }
+    }
+
+    fun getRecipeDetail(index: Long) {
+        viewModelScope.launch {
+            getRecipeDetailUseCase(index)
+                .onSuccess {
+                    _recipeUiState.value = UiState.Success(it)
+                }.onFailure {
+                    it.exceptionHandling(
+                        unauthorizedAction = { _recipeUiState.value = UiState.Unauthorized },
+                        notFoundAction = { _recipeUiState.value = UiState.NotFound }
                     )
                 }
         }


### PR DESCRIPTION
- SoloRecipeButton 텍스트 색상 지정할 수 있도록 변경
- 등록한 글 수정/삭제 페이지로 navigation 및 아이콘 추가
- 레시피 수정 시 기존에 작성된 데이터 불러오기