### PR TITLE
🔀 :: (#166) 앱 로고 클릭 이벤트 삭제

### DIFF
--- a/app/src/main/java/com/project/solorecipe/SoloRecipeNavHost.kt
+++ b/app/src/main/java/com/project/solorecipe/SoloRecipeNavHost.kt
@@ -33,7 +33,11 @@ fun SoloRecipeNavHost(
         signUpScreen(navigateToSignIn = {
             navController.navigateToSignIn()
         })
-        detailScreen()
+        detailScreen(
+            navigateToPrevious = {
+                navController.popBackStack()
+            }
+        )
         mainScreen(
             navigateToProfile = {
                 navController.navigateToProfile()
@@ -45,11 +49,27 @@ fun SoloRecipeNavHost(
                 navController.navigateToRegistration()
             }
         )
-        registrationScreen(navigateToMain = {
-            navController.navigateToMain()
-        })
-        profileScreen(navigateToSignIn = {
-            navController.navigateToSignIn()
-        })
+        registrationScreen(
+            navigateToMain = {
+                navController.navigateToMain()
+            },
+            navigateToPrevious = {
+                navController.popBackStack()
+            }
+        )
+        profileScreen(
+            navigateToSignIn = {
+                navController.navigateToSignIn()
+            },
+            navigateToDetail = {
+                navController.navigateToDetail(it, true)
+            },
+            navigateToRegistration = {
+                navController.navigateToRegistration("modify", it)
+            },
+            navigateToPrevious = {
+                navController.popBackStack()
+            }
+        )
     }
 }

--- a/design_system/src/main/java/com/project/design_system/component/SoloRecipeAppBar.kt
+++ b/design_system/src/main/java/com/project/design_system/component/SoloRecipeAppBar.kt
@@ -55,7 +55,7 @@ fun SoloRecipeAppBar(
             modifier = modifier
                 .fillMaxHeight()
                 .padding(start = 16.dp)
-                .clickable { onStartIconClick() },
+                .clickable(enabled = startIcon == null) { onStartIconClick() },
             contentAlignment = Alignment.Center
         ) {
             startIcon?.let { startIcon ->

--- a/presentation/src/main/java/com/project/presentation/view/detail/DetailScreen.kt
+++ b/presentation/src/main/java/com/project/presentation/view/detail/DetailScreen.kt
@@ -57,6 +57,7 @@ fun DetailScreen(
     index: String?,
     isLikedRecipe: Boolean?,
     detailViewModel: DetailViewModel = hiltViewModel(),
+    navigateToPrevious: () -> Unit
 ) {
     val recipeIndex = checkNotNull(index)
 
@@ -70,7 +71,7 @@ fun DetailScreen(
         UiState.Loading -> {}
         is UiState.Success -> {
             Column(modifier = modifier.fillMaxSize()) {
-                SoloRecipeAppBar { }
+                SoloRecipeAppBar { navigateToPrevious() }
                 Column(
                     modifier = modifier
                         .fillMaxSize()

--- a/presentation/src/main/java/com/project/presentation/view/detail/navigation/DetailNavigation.kt
+++ b/presentation/src/main/java/com/project/presentation/view/detail/navigation/DetailNavigation.kt
@@ -14,7 +14,9 @@ fun NavController.navigateToDetail(index: Long, isLikedRecipe: Boolean = false) 
     this.navigate("$detailRoute/$index/$isLikedRecipe")
 }
 
-fun NavGraphBuilder.detailScreen() {
+fun NavGraphBuilder.detailScreen(
+    navigateToPrevious: () -> Unit
+) {
     composable(
         route = "$detailRoute/{index}/{isLikedRecipe}",
         arguments = listOf(
@@ -24,7 +26,8 @@ fun NavGraphBuilder.detailScreen() {
     ) { backStackEntry ->
         DetailScreen(
             index = backStackEntry.arguments?.getString("index"),
-            isLikedRecipe = backStackEntry.arguments?.getBoolean("isLikedRecipe")
+            isLikedRecipe = backStackEntry.arguments?.getBoolean("isLikedRecipe"),
+            navigateToPrevious = navigateToPrevious
         )
     }
 }

--- a/presentation/src/main/java/com/project/presentation/view/profile/ProfileScreen.kt
+++ b/presentation/src/main/java/com/project/presentation/view/profile/ProfileScreen.kt
@@ -41,7 +41,6 @@ import com.project.design_system.component.SoloRecipeItem
 import com.project.design_system.theme.Body2
 import com.project.design_system.theme.Body4
 import com.project.design_system.theme.IcPencil
-import com.project.design_system.theme.IcProfile
 import com.project.design_system.theme.SoloRecipeColor
 import com.project.domain.model.profile.request.ProfileRequestModel
 import com.project.domain.model.profile.response.ProfileResponseModel
@@ -58,7 +57,10 @@ import com.skydoves.landscapist.glide.GlideImage
 fun ProfileScreen(
     modifier: Modifier = Modifier,
     profileViewModel: ProfileViewModel = hiltViewModel(),
-    navigateToSignIn: () -> Unit
+    navigateToSignIn: () -> Unit,
+    navigateToDetail: (Long) -> Unit,
+    navigateToRegistration: (Long) -> Unit,
+    navigateToPrevious: () -> Unit
 ) {
     LaunchedEffect(Unit) {
         profileViewModel.getUserInfo()
@@ -85,7 +87,7 @@ fun ProfileScreen(
                     .fillMaxSize()
                     .background(SoloRecipeColor.White)
             ) {
-                SoloRecipeAppBar { }
+                SoloRecipeAppBar { navigateToPrevious() }
                 Divider(
                     modifier = modifier.fillMaxWidth(),
                     color = SoloRecipeColor.Secondary10,
@@ -103,9 +105,15 @@ fun ProfileScreen(
                     thickness = 1.dp
                 )
                 Spacer(modifier = modifier.height(35.dp))
-                MyRecipeList(myRecipes = state.data?.myRecipe)
+                MyRecipeList(
+                    myRecipes = state.data?.myRecipe,
+                    navigateToRegistration = navigateToRegistration
+                )
                 Spacer(modifier = modifier.height(18.dp))
-                LikedRecipeList(likedRecipes = state.data?.likeRecipe)
+                LikedRecipeList(
+                    likedRecipes = state.data?.likeRecipe,
+                    navigateToDetail = navigateToDetail
+                )
                 Spacer(modifier = modifier.height(38.dp))
                 Divider(
                     modifier = modifier.fillMaxWidth(),
@@ -188,6 +196,7 @@ fun UserInfo(
 fun MyRecipeList(
     modifier: Modifier = Modifier,
     myRecipes: List<ProfileResponseModel>?,
+    navigateToRegistration: (Long) -> Unit
 ) {
     Box(
         modifier = modifier
@@ -198,9 +207,12 @@ fun MyRecipeList(
         Spacer(modifier = modifier.height(30.dp))
         LazyRow {
             items(myRecipes?.size ?: 0) {
+                val idx = myRecipes!![it].idx
+
                 SoloRecipeItem(
-                    imageUrl = myRecipes?.get(it)?.thumbnail ?: "",
-                    content = { Body4(text = myRecipes?.get(it)?.name ?: "") }
+                    modifier = modifier.clickable { navigateToRegistration(idx) },
+                    imageUrl = myRecipes[it].thumbnail,
+                    content = { Body4(text = myRecipes[it].name) }
                 )
             }
         }
@@ -210,7 +222,8 @@ fun MyRecipeList(
 @Composable
 fun LikedRecipeList(
     modifier: Modifier = Modifier,
-    likedRecipes: List<ProfileResponseModel>?
+    likedRecipes: List<ProfileResponseModel>?,
+    navigateToDetail: (Long) -> Unit,
 ) {
     Box(
         modifier = modifier
@@ -221,9 +234,12 @@ fun LikedRecipeList(
         Spacer(modifier = modifier.height(30.dp))
         LazyRow {
             items(likedRecipes?.size ?: 0) {
+                val idx = likedRecipes!![it].idx
+
                 SoloRecipeItem(
-                    imageUrl = likedRecipes?.get(it)?.thumbnail ?: "",
-                    content = { Body4(text = likedRecipes?.get(it)?.name ?: "") }
+                    modifier = modifier.clickable { navigateToDetail(idx) },
+                    imageUrl = likedRecipes[it].thumbnail,
+                    content = { Body4(text = likedRecipes[it].name) }
                 )
             }
         }

--- a/presentation/src/main/java/com/project/presentation/view/profile/navigation/ProfileNavigation.kt
+++ b/presentation/src/main/java/com/project/presentation/view/profile/navigation/ProfileNavigation.kt
@@ -11,8 +11,18 @@ fun NavController.navigateToProfile() {
     this.navigate(profileRoute)
 }
 
-fun NavGraphBuilder.profileScreen(navigateToSignIn: () -> Unit) {
+fun NavGraphBuilder.profileScreen(
+    navigateToSignIn: () -> Unit,
+    navigateToDetail: (Long) -> Unit,
+    navigateToRegistration: (Long) -> Unit,
+    navigateToPrevious: () -> Unit
+) {
     composable(profileRoute) {
-        ProfileScreen(navigateToSignIn = navigateToSignIn)
+        ProfileScreen(
+            navigateToSignIn = navigateToSignIn,
+            navigateToDetail = navigateToDetail,
+            navigateToRegistration = navigateToRegistration,
+            navigateToPrevious = navigateToPrevious
+        )
     }
 }

--- a/presentation/src/main/java/com/project/presentation/view/registration/RegistrationScreen.kt
+++ b/presentation/src/main/java/com/project/presentation/view/registration/RegistrationScreen.kt
@@ -73,6 +73,7 @@ fun RegistrationScreen(
     index: String?,
     type: String?,
     navigateToMain: () -> Unit,
+    navigateToPrevious: () -> Unit
 ) {
     val recipeProcess: List<RecipeRequestModel> = listOf()
 
@@ -194,7 +195,7 @@ fun RegistrationScreen(
                 }
             }
         ) {
-
+            navigateToPrevious()
         }
         Column(modifier = modifier.verticalScroll(rememberScrollState())) {
             Spacer(modifier = modifier.height(16.dp))

--- a/presentation/src/main/java/com/project/presentation/view/registration/navigation/RegistrationNavigation.kt
+++ b/presentation/src/main/java/com/project/presentation/view/registration/navigation/RegistrationNavigation.kt
@@ -14,7 +14,10 @@ fun NavController.navigateToRegistration(type: String = "registration", index: L
     this.navigate(route)
 }
 
-fun NavGraphBuilder.registrationScreen(navigateToMain: () -> Unit) {
+fun NavGraphBuilder.registrationScreen(
+    navigateToMain: () -> Unit,
+    navigateToPrevious: () -> Unit
+) {
     composable(
         route = "$registrationRoute/{type}?index={index}",
         arguments = listOf(
@@ -28,7 +31,8 @@ fun NavGraphBuilder.registrationScreen(navigateToMain: () -> Unit) {
         RegistrationScreen(
             type = backStackEntry.arguments?.getString("type"),
             index = backStackEntry.arguments?.getString("index"),
-            navigateToMain = navigateToMain
+            navigateToMain = navigateToMain,
+            navigateToPrevious = navigateToPrevious
         )
     }
 }


### PR DESCRIPTION
- 앱 로고 클릭 이벤트를 삭제
- 뒤로가기 버튼 클릭시 이전 페이지로 이동하도록 구현