### PR TITLE
🔀 :: (#204) 레시피 수정 페이지 로직 구현

### DIFF
--- a/app/src/main/java/com/project/solorecipe/SoloRecipeNavHost.kt
+++ b/app/src/main/java/com/project/solorecipe/SoloRecipeNavHost.kt
@@ -91,8 +91,13 @@ fun SoloRecipeNavHost(
                 navController.navigateToDetail(it)
             }
         )
-        modifyScreen(navigateToPrevious = {
-            navController.popBackStack()
-        })
+        modifyScreen(
+            navigateToProfile = {
+                navController.navigateToProfile()
+            },
+            navigateToPrevious = {
+                navController.popBackStack()
+            }
+        )
     }
 }

--- a/presentation/src/main/java/com/project/presentation/view/modify/navigation/ModifyNavigation.kt
+++ b/presentation/src/main/java/com/project/presentation/view/modify/navigation/ModifyNavigation.kt
@@ -14,6 +14,7 @@ fun NavController.navigateToModify(index: Long) {
 }
 
 fun NavGraphBuilder.modifyScreen(
+    navigateToProfile: () -> Unit,
     navigateToPrevious: () -> Unit
 ) {
     composable(
@@ -22,6 +23,7 @@ fun NavGraphBuilder.modifyScreen(
     ) { backStackEntry ->
         ModifyScreen(
             index = backStackEntry.arguments?.getLong("index"),
+            navigateToProfile = navigateToProfile,
             navigateToPrevious = navigateToPrevious
         )
     }

--- a/presentation/src/main/java/com/project/presentation/view/registration/RegistrationScreen.kt
+++ b/presentation/src/main/java/com/project/presentation/view/registration/RegistrationScreen.kt
@@ -187,6 +187,7 @@ fun Thumbnail(
         imageModel = { image.ifEmpty { registrationImageUri.value } },
         modifier = Modifier
             .fillMaxWidth()
+            .padding(horizontal = 26.dp)
             .height(250.dp)
             .clip(shape = RoundedCornerShape(8.dp))
             .clickable(
@@ -200,7 +201,6 @@ fun Thumbnail(
                 modifier = modifier
                     .fillMaxWidth()
                     .height(250.dp)
-                    .padding(horizontal = 26.dp)
                     .background(
                         color = SoloRecipeColor.Secondary10,
                         shape = RoundedCornerShape(8.dp)


### PR DESCRIPTION
- RegistrationScreen의 StepItem에서 horizontalPadding을 상위 뷰로 이동
- 레시피 수정 및 삭제 로직 구현